### PR TITLE
feat: 401 에러 시 auth로 리다이렉트

### DIFF
--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,28 @@
+'use client'; // Error components must be Client Components
+
+import { useEffect } from 'react';
+import { redirect } from 'next/navigation';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error;
+  reset: () => void;
+}) {
+  if (error.message === '401') redirect('/auth');
+
+  return (
+    <div>
+      <h2>Something went wrong!</h2>
+      <button
+        onClick={
+          // Attempt to recover by trying to re-render the segment
+          () => reset()
+        }
+      >
+        Try again
+      </button>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,9 @@
 'use client';
 
 import { useQueries } from '@tanstack/react-query';
+
 import { getMe } from '@/services';
-
-async function getArticles() {
-  const res = await fetch('http://localhost:8888/articles?order=DESC&page=1&take=10&categoryId=1', {
-    credentials: 'include',
-  });
-
-  const data = res.json();
-
-  if (res.status !== 200) {
-    throw new Error();
-  }
-
-  return data;
-}
+import { getArticles } from '@/services/getArticles';
 
 export default function Page() {
   const [{ data: myData, isError }, { data: articleData }] = useQueries({
@@ -23,15 +11,20 @@ export default function Page() {
       { queryKey: ['me'], queryFn: () => getMe() },
       {
         queryKey: ['articles'],
-        queryFn: () => getArticles(),
+        queryFn: () =>
+          getArticles({ order: 'DESC', page: 1, take: 10, categoryId: 1 }),
       },
     ],
   });
 
   return (
     <>
-      <h1 className='w-100 h-40 text-3xl font-bold underline'>Rookies 홈이지롱!!</h1>
-      {isError ? <pre>에러 ㅋ</pre> : <pre>{JSON.stringify(myData, null, 2)}</pre>}
+      <h1>Rookies 홈이지롱!!</h1>
+      {isError ? (
+        <pre>에러 ㅋ</pre>
+      ) : (
+        <pre>{JSON.stringify(myData, null, 2)}</pre>
+      )}
       {articleData &&
         articleData.data.map((article: any) => (
           <ul key={article.id}>

--- a/src/libs/fetch.ts
+++ b/src/libs/fetch.ts
@@ -1,6 +1,15 @@
-async function request<TResponse>(path: string, config: RequestInit = {}): Promise<TResponse> {
-  const baseUrl = (process.env.NEXT_PUBLIC_BASE_URL ?? 'https://api-alpha.42world.kr') + path;
+async function request<TResponse>(
+  path: string,
+  config: RequestInit = {}
+): Promise<TResponse> {
+  const baseUrl =
+    (process.env.NEXT_PUBLIC_BASE_URL ?? 'https://api-alpha.42world.kr') + path;
+
   const res = await fetch(baseUrl, config);
+
+  if (res.status !== 200) {
+    throw new Error('401');
+  }
   return await res.json();
 }
 

--- a/src/libs/provider.tsx
+++ b/src/libs/provider.tsx
@@ -1,11 +1,21 @@
 'use client';
 
 import { useState } from 'react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 function Provider({ children }: React.PropsWithChildren) {
-  const [client] = useState(new QueryClient({ defaultOptions: { queries: { staleTime: 5000 } } }));
+  const [client] = useState(
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: 0,
+          staleTime: 5000,
+          useErrorBoundary: (error) => (error as Error).message === '401',
+        },
+      },
+    })
+  );
 
   return (
     <QueryClientProvider client={client}>


### PR DESCRIPTION
# :eyes: What is this PR?

401 에러 시 /auth로 리다이렉트 되도록 설정했는데요..
아직 완성은 아니고 에러 status 마다 어떻게 에러 핸들링할지 정한 다음에 고도화해야할 것 같아요..
일요일에 말도 없이 빠져서 죄송합니다

# :pencil: Changes
- `app/page.tsx`에서 getArticles.ts에 있는 함수 사용하는 걸로 수정했고,,
- `libs/fetch.ts`에서 일단 200아닐 때 에러 던지도록 수정했습니다..
- `libs/provider.tsx에서 에러 메시지 '401'일 때만 에러 바운더리 사용하도록 해놨고..
- `pages/error.tsx`에서 에러 메시지 '401'일 때 /auth로 리다이렉트 되도록 설정..했습니다..

status 가지고 있는 커스텀 에러 클래스 같은 거 만들어서? 수정해야할 것 같아요

## :pushpin: Related issue(s)
-   #16  

## :camera: Attachment(optional)
